### PR TITLE
Add explicit filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ services:
     environment:
       - thread_limit=1
       - crop_album_art=false
+      - allow_explicit=true
     restart: unless-stopped
 ```
 
@@ -36,6 +37,7 @@ Certain values can be set via environment variables:
 * __PGID__: The group ID to run the app with. Defaults to `1000`.
 * __thread_limit__: Max number of threads to use. Defaults to `1`.
 * __crop_album_art__: Set this to `true` to force the creation of square album art instead of using the 16:9 aspect ratio from YouTube. Defaults to `false`.
+* __allow_explicit__: Set this to `false` to prevent explicit version of songs from being downloaded. Defaults to `true`.
 
 
 ## Sync Schedule

--- a/src/Syncify.py
+++ b/src/Syncify.py
@@ -44,6 +44,7 @@ class DataHandler:
         self.thread_limit = int(os.environ.get("thread_limit", 1))
         self.media_server_scan_req_flag = False
         self.crop_album_art = os.getenv("crop_album_art", "false").lower()
+        self.allow_explicit = os.getenv("allow_explicit", "true").lower()
 
         if not os.path.exists(self.config_folder):
             os.makedirs(self.config_folder)
@@ -227,6 +228,9 @@ class DataHandler:
 
             self.ytmusic = YTMusic()
             search_results = self.ytmusic.search(query=f"{artist} - {title}", filter="songs", limit=5)
+
+            # Filter for explicit tracks
+            search_results = [track for track in search_results if self.allow_explicit and track.get("isExplicit")]
 
             cleaned_artist = self.string_cleaner(artist).lower()
             cleaned_title = self.string_cleaner(title).lower()


### PR DESCRIPTION
This PR solves the issue of yt-dlp downloading censored version of songs when the explicit version may be more desirable. It does this by adding a `allow_explicit` environmental variable and filtering the search results if it is set to true.

This worked for my personal use case. Let me know if there are any issues.