### PR TITLE
Add support for resuming after app crash

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  syncify:
+    build: .
+    container_name: syncify
+    ports:
+      - "5000:5000"
+    volumes:
+      - ./config:/syncify/config
+      - ./downloads:/syncify/downloads
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - thread_limit=1
+      # - crop_album_art=true
+    restart: unless-stopped


### PR DESCRIPTION
## Motivation

I run Syncify in my home Kubernetes cluster. As such, it is subject to being killed and rescheduled at any time. This change adds support for resuming whatever task was in-flight during an app crash (parsing a playlist, resuming downloads, etc).

> Note: To be fully transparent, this is all Claude Code's handiwork, so take what's here with a grain of salt. But my local testing confirmed things are working as (at least I) expected.

I also added a docker compose file to help with that local testing.

Hope others find this useful!